### PR TITLE
docs: document activity log, atlas dashboard, and anonymous bans

### DIFF
--- a/docs/admin-responsibilities-and-powers.md
+++ b/docs/admin-responsibilities-and-powers.md
@@ -14,6 +14,7 @@ They can:
 - manage the whitelist,
 - bypass registration restrictions for players,
 - scramble maps available in the votes,
+- review the [activity log](/docs/website-settings#activity-log) of administrative and game events,
 - edit static pages (like the rules page).
 
 They are supposed to:

--- a/docs/site-components-deployment.md
+++ b/docs/site-components-deployment.md
@@ -141,6 +141,12 @@ SERVEME_TF_API_KEY=your_serveme_tf_api_key
 # TF2_QUICK_SERVER_CLIENT_ID=your_client_id
 # TF2_QUICK_SERVER_CLIENT_SECRET=your_client_secret
 
+# atlas integration (optional)
+# Registers this instance on the atlas dashboard (https://atlas.tf2pickup.org).
+# Heartbeats are sent only when ATLAS_SECRET is set.
+# ATLAS_URL=https://atlas.tf2pickup.org
+# ATLAS_SECRET=your_atlas_secret
+
 ### Mumble Server Configuration
 # SuperUser account password
 MUMBLE_SUPERUSER_PASSWORD=XDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXDXD
@@ -294,6 +300,28 @@ Then, you will see the application list. Find `tf2pickup.eu` and select **Manage
 ![twitch-dev-console-api-settings](/img/content/site-components-deployment/twitch-dev-console-api-settings.png)
 
 Pass this secret value to the `TWITCH_CLIENT_SECRET` variable.
+
+### Registering on the atlas dashboard
+
+:::tip
+
+This step is optional. Follow it only if you want your instance to appear on the public [atlas.tf2pickup.org](https://atlas.tf2pickup.org) dashboard.
+
+:::
+
+[atlas.tf2pickup.org](https://atlas.tf2pickup.org) is a dashboard that lists all online _tf2pickup.org_ instances. Each registered instance is shown together with its name, address, application version, queue configuration, queue occupancy and the number of players currently online. A link to the dashboard is also available in the footer of every _tf2pickup.org_ instance.
+
+To register your instance, set the `ATLAS_SECRET` environment variable in your `.env` file. Once it is set, the instance sends an authenticated heartbeat to atlas at boot, every 3 minutes, and whenever the queue changes. If a heartbeat is not received for 12 hours, the instance is dropped from the dashboard.
+
+```env
+# atlas integration (optional)
+# Registers this instance on the atlas dashboard (https://atlas.tf2pickup.org).
+# Heartbeats are sent only when ATLAS_SECRET is set.
+# ATLAS_URL=https://atlas.tf2pickup.org
+ATLAS_SECRET=your_atlas_secret
+```
+
+`ATLAS_URL` defaults to `https://atlas.tf2pickup.org` and only needs to be set if you run your own atlas instance. The feature is fully optional — when `ATLAS_SECRET` is unset (the default), nothing is registered, and if atlas is unreachable the instance keeps working normally and only logs a warning.
 
 ### Mumble server setup
 

--- a/docs/the-most-common-tasks.md
+++ b/docs/the-most-common-tasks.md
@@ -137,6 +137,12 @@ Then navigate to the `Bans` tab and click `Add ban`.
 
 Define a ban reason and the ban length. You can define a ban length by the duration, end date or without due date, meaning someone is getting banned forever. Click `Save` after that.
 
+### Anonymous bans
+
+When adding a ban, you can tick the **Anonymous** checkbox. The banned player (and anyone else viewing the ban) will see it as issued by **&lt;your website name&gt; Staff** instead of your nickname. Admins still see who actually issued the ban — in the player's ban history, an anonymous ban is marked with an _(anonymous)_ label next to the real actor's name.
+
+Use this when you want to hand out a ban without exposing which individual admin issued it.
+
 ![ban-player-duration](/img/content/common-tasks/ban-player-duration.png)
 
 ![ban-player-enddate](/img/content/common-tasks/ban-player-enddate.png)

--- a/docs/website-settings.md
+++ b/docs/website-settings.md
@@ -17,6 +17,7 @@ Currently website settings lets you:
 - import player skill,
 - show site player skill table,
 - scramble maps available to vote at the moment,
+- review the activity log,
 - edit rules,
 - edit privacy policy.
 
@@ -210,6 +211,31 @@ If a player had a failed login attempt due to registration restrictions, let the
 ## Setting up player skills
 
 See [here](/docs/the-most-common-tasks#setting-up-player-skills).
+
+## Activity log
+
+The admin panel includes an **Activity log** — a paginated, filterable table that records significant administrative and game events on the site. Open it from the admin panel or directly at `/admin/activity-log`.
+
+The log tracks events such as:
+
+- player name changes (with the actor, when changed by an admin),
+- player skill changes (showing the before/after values),
+- configuration changes (only when a value actually changes — saving without a change records nothing),
+- bans added and revoked (with reason and expiry/revoke details),
+- map pool changes and map scrambles,
+- games reconfigured, game servers reassigned, and games force-ended,
+- substitute requests,
+- queue clears (showing how many players were removed).
+
+You can filter entries by **type**, **player**, and **actor**. The player and actor filters accept either a name search or a direct SteamID64. The current filter and sort state is kept in the page's query string, so you can share a link to a filtered view with other admins. Click the date column header to toggle the sort order.
+
+:::tip
+Each player's admin toolbox includes an **Activity log** link that opens the log pre-filtered to that player (`/admin/activity-log?player=<steamId>`).
+:::
+
+:::note
+Consecutive map scrambles by the same admin are merged into a single entry with a ×N counter to keep the log readable. Historical entries are backfilled from existing name history, skill history and game events the first time the feature runs, so the log is not empty on upgrade.
+:::
 
 ## Set up website rules
 


### PR DESCRIPTION
Documents new features and improvements from recent tf2pickup.org releases.

## Changes

- **Admin activity log** ([tf2pickup#650](https://github.com/tf2pickup-org/tf2pickup/pull/650)) — new "Activity log" section in `website-settings.md` covering tracked event types, type/player/actor filtering, shareable query-string state, the per-player toolbox link, scramble batching, and the historical backfill. Added to the settings overview list and the admin powers list.
- **Atlas dashboard** ([tf2pickup#658](https://github.com/tf2pickup-org/tf2pickup/pull/658)) — new section in `site-components-deployment.md` describing [atlas.tf2pickup.org](https://atlas.tf2pickup.org), the heartbeat behavior, the footer link, and the optional `ATLAS_URL` / `ATLAS_SECRET` env vars.
- **Anonymous bans** ([tf2pickup#666](https://github.com/tf2pickup-org/tf2pickup/pull/666)) — new subsection under "Handing out bans" in `the-most-common-tasks.md`.
- **Skill suggestions** ([tf2pickup#589](https://github.com/tf2pickup-org/tf2pickup/pull/589)) — already documented; verified the "on by default" claim still matches the source.

Verified with `docusaurus build` (no broken-link errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)