### PR TITLE
docs: spectator server-info hiding and player profile deletion

### DIFF
--- a/docs/admin-responsibilities-and-powers.md
+++ b/docs/admin-responsibilities-and-powers.md
@@ -17,6 +17,11 @@ They can:
 - review the [activity log](/docs/website-settings#activity-log) of administrative and game events,
 - edit static pages (like the rules page).
 
+Super-users additionally can:
+
+- [permanently delete a player profile](/docs/website-settings#deleting-a-player-profile) (irreversible),
+- control whether [server connect info is hidden from spectators](/docs/final-touches#hiding-server-info-from-spectators).
+
 They are supposed to:
 
 - consult actions if they are unsure if things what they want to do are fine (for example handing out bans, assigning skills to certain people, changing site elements such as map pool, rules or the whitelist),

--- a/docs/final-touches.md
+++ b/docs/final-touches.md
@@ -85,6 +85,25 @@ Available regions: São Paulo, Santiago, Bogotá, Chicago, Frankfurt, Sydney.
 tf2-quick-server can be used alongside static servers and serveme.tf. The site uses whichever provider you select when assigning a server to a game.
 :::
 
+### Hiding server info from spectators
+
+SourceTV runs on the same machine (and therefore the same IP address) as the game server, so the SourceTV connect string shown to non-participants exposes the game server's address. This can be scraped and abused for DDoS attacks. To mitigate this, **Admin Panel → Game servers** includes a **Hide server info from spectators** setting with three modes:
+
+- **never** — show connect info to everyone (the previous behavior).
+- **auto** *(default)* — hide connect info only for non-serveme.tf servers. serveme.tf has built-in DDoS protection, so reservations there stay visible.
+- **always** — hide connect info for all servers.
+
+When connect info is hidden, non-participants see `hidden` instead of the SourceTV connect string, and the **watch stv** button is removed for them.
+
+The following always keep access to the real connect info, regardless of this setting:
+
+- **Match participants** — always see the real game connect string.
+- **Admins** (even when not playing in the game) — always see the SourceTV connect string and keep the **watch stv** button, since they are trusted and already have the full rcon connect string in the admin toolbox.
+
+:::note
+Because SourceTV shares the game server's IP, hiding the address from non-participants necessarily disables public SourceTV spectating for the affected servers while a game is live. There is no way to keep public STV available while still hiding the address.
+:::
+
 ## Add admins to the site, set up whitelist, maps and skills
 
 After the site start, you may want to add admins in order to make site moderation easier and faster. To do that, you have to open up the player profile, choose **roles** button and choose a right role for them:

--- a/docs/website-settings.md
+++ b/docs/website-settings.md
@@ -18,6 +18,7 @@ Currently website settings lets you:
 - show site player skill table,
 - scramble maps available to vote at the moment,
 - review the activity log,
+- delete player profiles (super-users only),
 - edit rules,
 - edit privacy policy.
 
@@ -235,6 +236,27 @@ Each player's admin toolbox includes an **Activity log** link that opens the log
 
 :::note
 Consecutive map scrambles by the same admin are merged into a single entry with a ×N counter to keep the log readable. Historical entries are backfilled from existing name history, skill history and game events the first time the feature runs, so the log is not empty on upgrade.
+:::
+
+## Deleting a player profile
+
+:::warning
+This action is **irreversible**. There is no undo and no recycle bin — once a profile is deleted it cannot be restored.
+:::
+
+Super-users can permanently delete a player profile. Open it from the admin panel or directly at `/admin/delete-player`.
+
+Search for a player by name or SteamID64, then use the per-player card to delete them. To prevent mistakes, deletion requires typing the player's exact nickname or SteamID64 (validated on the server) and confirming a browser dialog.
+
+When a profile is deleted:
+
+- The player document is **hard-deleted**, so the profile page returns a 404 and the player disappears from the player list and the hall of fame.
+- Historical references in games, chat and the activity log are **anonymized** — the player's Steam ID is replaced with a `[deleted]` sentinel, and they render as a greyed-out "deleted user" with no profile link. Chat mentions (both the rendered link and the `@<id>` token) are scrubbed too.
+- **Player action logs keep the real Steam ID** for auditing. The profile link there becomes a dead link, but the Steam ID remains visible in its own column.
+- Live presence (online players, queue slots, friendships) is cleared so no live views break.
+
+:::note
+Super-users cannot be deleted. Their card shows "cannot be deleted", and the server re-enforces this even if the request is crafted manually.
 :::
 
 ## Set up website rules


### PR DESCRIPTION
## What

Documents recently added admin features from the main `tf2pickup` repo.

### Hide server info from spectators (tf2pickup-org/tf2pickup#697, tf2pickup-org/tf2pickup#699)

New subsection in **For server admins → Final touches → Adding game servers**:

- The **Admin → Game servers** *Hide server info from spectators* setting with its three modes (`never`, `auto` default, `always`).
- The DDoS rationale (SourceTV shares the game server's IP).
- Visibility exceptions: match participants always see the real connect string; admins keep the SourceTV string and the *watch stv* button even when not playing (#699).
- The tradeoff note that hiding the address disables public STV while a game is live.

### Delete player profiles (tf2pickup-org/tf2pickup#684)

New *Deleting a player profile* section in **Website settings**:

- Super-user-only `/admin/delete-player` flow with the typed-confirmation safeguard.
- What gets hard-deleted (profile/list/hall of fame) vs anonymized (`[deleted]` in games, chat, activity log).
- Action logs intentionally keep the real Steam ID for auditing.
- Super-users cannot be deleted.

### Cross-references

- New "Super-users additionally can…" list in **Admin responsibilities and powers**.
- Added the delete-player page to the website settings overview list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)